### PR TITLE
Add grasshopper functionality to js compute client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/compute.rhino3d.js
+++ b/compute.rhino3d.js
@@ -1,12 +1,5 @@
-// check if we're running in a browser or in node.js
-let _is_node = typeof exports === 'object' && typeof module === 'object'
-
-// (node.js) polyfill fetch
-if (_is_node && typeof fetch !== 'function' && typeof require === 'function')
-    fetch = require('node-fetch')
-
 var RhinoCompute = {
-    version: "0.6.0",
+    version: "0.9.0",
 
     url: "https://compute.rhino3d.com/",
 
@@ -3627,8 +3620,133 @@ var RhinoCompute = {
             return promise;
         },
     },
+    Grasshopper: {
+        DataTree: class {
+            constructor(name) {
+                this.data = { 'ParamName': name, 'InnerTree': {} }
+            }
+
+            append(path, items) {
+                // Append a path to this tree
+                //
+                // Args:
+                //     path (arr): a list of integers defining a path
+                //     items (arr): list of data to add to the tree
+
+                var key = path.join(';')
+                var innerTreeData = []
+                items.forEach(item => {
+                    innerTreeData.push({ 'data': item })
+                })
+                this.data.InnerTree[key] = innerTreeData
+            }
+        },
+        evaluateDefinition : function(definition, trees) {
+            // Evaluate a grasshopper definition on the compute server.
+            //
+            // Args:
+            //     definition (str/bytearray): contents of .gh/.ghx file
+            //     trees (arr): list of DataTree instances
+            // Returns:
+
+            var url = 'grasshopper';
+            args = { 'algo': null, 'pointer': null, 'values': null };
+
+            if (definition.constructor === Uint8Array)
+                args['algo'] = base64ByteArray(definition)
+            else
+                args['algo'] = btoa(definition);
+
+            var values = [];
+            trees.forEach(tree => {
+                values.push(tree.data);
+            });
+            args['values'] = values;
+
+            var promise = RhinoCompute.computeFetch(url, args);
+            return promise;
+        }
+    }
 };
 
-// (node.js) export RhinoCompute object
+// https://gist.github.com/jonleighton/958841
+/*
+MIT LICENSE
+Copyright 2011 Jon Leighton
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+function base64ByteArray(bytes) {
+    var base64    = ''
+    var encodings = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+    // var bytes         = new Uint8Array(arrayBuffer)
+
+    // strip bom
+    if (bytes[0] === 239 && bytes[1] === 187 && bytes[2] === 191)
+        bytes = bytes.slice(3)
+
+    var byteLength    = bytes.byteLength
+    var byteRemainder = byteLength % 3
+    var mainLength    = byteLength - byteRemainder
+
+    var a, b, c, d
+    var chunk
+
+    // Main loop deals with bytes in chunks of 3
+    for (var i = 0; i < mainLength; i = i + 3) {
+        // Combine the three bytes into a single integer
+        chunk = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2]
+
+        // Use bitmasks to extract 6-bit segments from the triplet
+        a = (chunk & 16515072) >> 18 // 16515072 = (2^6 - 1) << 18
+        b = (chunk & 258048)   >> 12 // 258048   = (2^6 - 1) << 12
+        c = (chunk & 4032)     >>  6 // 4032     = (2^6 - 1) << 6
+        d = chunk & 63               // 63       = 2^6 - 1
+
+        // Convert the raw binary segments to the appropriate ASCII encoding
+        base64 += encodings[a] + encodings[b] + encodings[c] + encodings[d]
+    }
+
+    // Deal with the remaining bytes and padding
+    if (byteRemainder == 1) {
+        chunk = bytes[mainLength]
+
+        a = (chunk & 252) >> 2 // 252 = (2^6 - 1) << 2
+
+        // Set the 4 least significant bits to zero
+        b = (chunk & 3)   << 4 // 3   = 2^2 - 1
+
+        base64 += encodings[a] + encodings[b] + '=='
+    } else if (byteRemainder == 2) {
+        chunk = (bytes[mainLength] << 8) | bytes[mainLength + 1]
+
+        a = (chunk & 64512) >> 10 // 64512 = (2^6 - 1) << 10
+        b = (chunk & 1008)  >>  4 // 1008  = (2^6 - 1) << 4
+
+        // Set the 2 least significant bits to zero
+        c = (chunk & 15)    <<  2 // 15    = 2^4 - 1
+
+        base64 += encodings[a] + encodings[b] + encodings[c] + '='
+    }
+
+    return base64
+}
+
+// NODE.JS
+
+// check if we're running in a browser or in node.js
+let _is_node = typeof exports === 'object' && typeof module === 'object'
+
+// polyfills
+if (_is_node && typeof require === 'function')
+{
+    if (typeof fetch !== 'function')
+        fetch = require('node-fetch')
+}
+
+// export RhinoCompute object
 if (_is_node)
     module.exports = RhinoCompute;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compute-rhino3d",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "description": "JavaScript library for compute.rhino3d.com geometry service",
   "main": "compute.rhino3d.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "author": "Robert McNeel & Associates",
   "license": "MIT",
   "bugs": {
-    "url": "https://mcneel.myjetbrains.com/youtrack/issues/COMPUTE"
+    "url": "https://github.com/mcneel/compute.rhino3d/issues"
   },
   "homepage": "https://github.com/mcneel/compute.rhino3d#readme",
   "dependencies": {


### PR DESCRIPTION
* Evaluate grasshopper definitions with `RhinoCompute.Grasshopper.evaluateDefinition()`
* Works with both .gh and .ghx files in node.js and in the browser
* Construct inputs with the `RhinoCompute.Grasshopper.DataTree` class

#### Node.js example
```js
compute = require('./compute.rhino3d.js')
fs = require('fs')

compute.url = 'https://staging.compute.rhino3d.com/'
compute.authToken = 'Bearer' + process.env.RHINO_COMPUTE_TOKEN

var buffer = fs.readFileSync('leland.gh')
var definition = new Uint8Array(buffer) // works for both .gh and .ghx

var tree = new compute.Grasshopper.DataTree('RH_IN:106:0001')
tree.append([0], ['Lorem ipsum dolor sit amet'])

compute.Grasshopper.evaluateDefinition(definition, [tree]).then(res => {
    console.log(JSON.stringify(res))
}).catch(err => {
    throw err
})
```

#### Browser example
```html
<html>
    <head>
        <script src="compute.rhino3d.js"></script>
        <script>
            RhinoCompute.url = 'https://staging.compute.rhino3d.com/'
            RhinoCompute.authToken = RhinoCompute.getAuthToken()

            var tree = new RhinoCompute.Grasshopper.DataTree('RH_IN:106:0001')
            tree.append([0], ['Lorem ipsum dolor sit amet'])
            var trees = [tree]

            fetch('leland.gh')

            // .gh
            .then(response => response.arrayBuffer())
            .then(buffer => new Uint8Array(buffer))

            // .ghx
            // .then(response => response.text())

            .then(definition => RhinoCompute.Grasshopper.evaluateDefinition(definition, [tree]))
            .then(res => console.log(JSON.stringify(res)))
            .catch(err => { throw err })
        </script>
    </head>
</html>
```

Example Grasshopper defintion – [leland.gh.zip](https://github.com/mcneel/computeclient_js/files/3836730/leland.gh.zip)